### PR TITLE
Snowball Edge Cross-Account AMI Sharing

### DIFF
--- a/doc_source/using-ec2.md
+++ b/doc_source/using-ec2.md
@@ -25,6 +25,7 @@ When you're done with your device, return it to AWS\. If the device was used in 
 
 **Important**  
 Using encrypted AMIs on Snowball Edge devices is not supported\.
+Using shared AMIs on Snowball Edge devices is not supported\.
 Data in compute instances running on a Snowball Edge isn't imported into AWS\.
 
 ### Compute Instances on Clusters<a name="ec2-overview-cluster"></a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When creating a Snowball Edge job with EC2  compute instances, the instances require Amazon Machine Images (AMIs) to launch. The available AMIs must be owned by the account that is creating the Snowball Edge job. This PR updates the documentation to make it clear that using shared AMIs is not supported. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
